### PR TITLE
Fixes & review of e2e tests

### DIFF
--- a/e2e/README.md
+++ b/e2e/README.md
@@ -9,6 +9,9 @@ End-To-End Tests written with cypress.io
 ## Setup
 
 ```sh
+# System dependencies for Cypress
+apt-get install libgtk2.0-0 libgtk-3-0 libgbm-dev libnotify-dev libgconf-2-4 libnss3 libxss1 libasound2 libxtst6 xauth xvfb
+
 npm install
 npm test
 ```

--- a/e2e/cypress/e2e/client-participation/embeds.cy.js
+++ b/e2e/cypress/e2e/client-participation/embeds.cy.js
@@ -1,6 +1,6 @@
-describe('Embedded Conversations', () => {
+describe.skip('Embedded Conversations', () => {
   // This test requires overriding client-admin/embed.html with
-  // e2e/cypress/fixtures/html/embeds.html
+  // e2e/cypress/fixtures/html/embeds.html - see https://github.com/compdemocracy/polis/issues/839
   const POLIS_DOMAIN = Cypress.config().baseUrl.replace('https://', '')
   const CONVO_DESCRIPTION = 'This is dummy description for embed tests.'
   const CONVO_TOPIC = 'Embed test topic'

--- a/e2e/cypress/e2e/client-participation/integration.cy.js
+++ b/e2e/cypress/e2e/client-participation/integration.cy.js
@@ -1,6 +1,6 @@
-describe('Integrated Conversations', () => {
+describe.skip('Integrated Conversations', () => {
   // This test requires overriding client-admin/embed.html with
-  // e2e/cypress/fixtures/html/embeds.html
+  // e2e/cypress/fixtures/html/embeds.html - see https://github.com/compdemocracy/polis/issues/839
   const POLIS_DOMAIN = Cypress.config().baseUrl.replace('https://', '')
   const CONVO_TOPIC = 'Integration test topic'
   const CONVO_DEFAULTS = {

--- a/e2e/cypress/support/commands.js
+++ b/e2e/cypress/support/commands.js
@@ -24,6 +24,10 @@
 // -- This will overwrite an existing command --
 // Cypress.Commands.overwrite("visit", (originalFn, url, options) => { ... })
 
+// Adds commands for using iframes.
+// See: https://gitlab.com/kgroat/cypress-iframe
+require('cypress-iframe')
+
 Cypress.Commands.add('logout', () => {
   cy.request('POST', Cypress.config().apiPath + '/auth/deregister').then(
     (resp) => {

--- a/e2e/package-lock.json
+++ b/e2e/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "devDependencies": {
         "cypress": "10.8.0",
+        "cypress-iframe": "^1.0.1",
         "cypress-terminal-report": "4.1.2",
         "eslint": "8.23.1",
         "eslint-config-prettier": "8.5.0",
@@ -181,6 +182,17 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/@types/cypress": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@types/cypress/-/cypress-1.1.3.tgz",
+      "integrity": "sha512-OXe0Gw8LeCflkG1oPgFpyrYWJmEKqYncBsD/J0r17r0ETx/TnIGDNLwXt/pFYSYuYTpzcq1q3g62M9DrfsBL4g==",
+      "deprecated": "This is a stub types definition for cypress (https://cypress.io). cypress provides its own type definitions, so you don't need @types/cypress installed!",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "cypress": "*"
       }
     },
     "node_modules/@types/json5": {
@@ -841,6 +853,15 @@
       },
       "engines": {
         "node": ">=12.0.0"
+      }
+    },
+    "node_modules/cypress-iframe": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/cypress-iframe/-/cypress-iframe-1.0.1.tgz",
+      "integrity": "sha512-Ne+xkZmWMhfq3x6wbfzK/SzsVTCrJru3R3cLXsoSAZyfUtJDamXyaIieHXeea3pQDXF4wE2w4iUuvCYHhoD31g==",
+      "dev": true,
+      "peerDependencies": {
+        "@types/cypress": "^1.1.0"
       }
     },
     "node_modules/cypress-terminal-report": {
@@ -4031,6 +4052,16 @@
         "fastq": "^1.6.0"
       }
     },
+    "@types/cypress": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@types/cypress/-/cypress-1.1.3.tgz",
+      "integrity": "sha512-OXe0Gw8LeCflkG1oPgFpyrYWJmEKqYncBsD/J0r17r0ETx/TnIGDNLwXt/pFYSYuYTpzcq1q3g62M9DrfsBL4g==",
+      "dev": true,
+      "peer": true,
+      "requires": {
+        "cypress": "*"
+      }
+    },
     "@types/json5": {
       "version": "0.0.29",
       "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
@@ -4520,6 +4551,13 @@
         "untildify": "^4.0.0",
         "yauzl": "^2.10.0"
       }
+    },
+    "cypress-iframe": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/cypress-iframe/-/cypress-iframe-1.0.1.tgz",
+      "integrity": "sha512-Ne+xkZmWMhfq3x6wbfzK/SzsVTCrJru3R3cLXsoSAZyfUtJDamXyaIieHXeea3pQDXF4wE2w4iUuvCYHhoD31g==",
+      "dev": true,
+      "requires": {}
     },
     "cypress-terminal-report": {
       "version": "4.1.2",

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -6,14 +6,15 @@
     "lint": "eslint .",
     "lint:fix": "eslint --fix .",
     "test": "npm run e2e:all",
-    "e2e:all": "cypress run --spec 'cypress/integration/polis/**' --browser=chrome",
-    "e2e:minimal": "cypress run --spec '**/kitchensink.cy.js' --browser=chrome",
-    "e2e:standalone": "cypress run --spec '**/polis/**/!(*.secrets).cy.js' --browser=chrome",
-    "e2e:secret": "cypress run --spec '**/(*.secrets).cy.js' --browser=chrome",
-    "e2e:subset": "cypress run --spec **/*${TEST_FILTER:-kitchensink}*.cy.js --browser=chrome --no-exit"
+    "e2e:all": "cypress run --spec 'cypress/e2e/**' --browser=electron",
+    "e2e:minimal": "cypress run --spec '**/kitchensink.cy.js' --browser=electron",
+    "e2e:standalone": "cypress run --spec 'cypress/e2e/**/!(*.secrets).cy.js' --browser=electron",
+    "e2e:secret": "cypress run --spec '**/(*.secrets).cy.js' --browser=electron",
+    "e2e:subset": "cypress run --spec **/*${TEST_FILTER:-kitchensink}*.cy.js --browser=electron --no-exit"
   },
   "devDependencies": {
     "cypress": "10.8.0",
+    "cypress-iframe": "^1.0.1",
     "cypress-terminal-report": "4.1.2",
     "eslint": "8.23.1",
     "eslint-config-prettier": "8.5.0",


### PR DESCRIPTION
Some fixes and a review of the e2e tests ...

* Removed Chrome dependency in favour of Electron built-in browser
* Restore missing reference to `cypress-iframe`
* Notes on iframe test lmitations and `skip` tag on iframe tests
* **Does not fix broken test in `configure.cy.js`**